### PR TITLE
Add support for nextcloud in sync engine

### DIFF
--- a/src/sync-account.cpp
+++ b/src/sync-account.cpp
@@ -905,7 +905,8 @@ void SyncAccount::fetchRemoteCalendarsFromCommand(const QString &username, const
     QString syncUrl(host());
 
     // Use well-known url that will re-direct to the correct path
-    if (providerName().toLower() == "owncloud") {
+    if (providerName().toLower() == "owncloud" ||
+        providerName().toLower() == "nextcloud") {
         syncUrl += QStringLiteral("/remote.php/caldav");
     }
 


### PR DESCRIPTION
This should be made controllable entirely via the .service file; I will
add a bug report for that.

Fixes: #4