### PR TITLE
EdsHelper: fix mapping of EDS sources with QtOrganizer collections

### DIFF
--- a/src/eds-helper.h
+++ b/src/eds-helper.h
@@ -63,6 +63,9 @@ public:
     EdsSource sourceByRemoteId(const QString &remoteId, uint account);
     EdsSource sourceById(const QString &id);
 
+    QString sourceFromCollectionId(const QOrganizerCollectionId &collectionId) const;
+    QOrganizerCollectionId sourceToCollectionId(const QString &sourceId) const;
+
     void freezeNotify();
     void unfreezeNotify();
     void flush();


### PR DESCRIPTION
Fixes: https://github.com/ubports/calendar-app/issues/116

NOTE: this fixes only the synchronization. I can see that there are still errors when editing recurrent events, but that issue will be fixed in another component.