### PR TITLE
Hide Sync Monitor Helper desktop entry

### DIFF
--- a/authenticator/syncmonitorhelper.desktop.in
+++ b/authenticator/syncmonitorhelper.desktop.in
@@ -6,5 +6,6 @@ Terminal=false
 Type=Application
 Version=1.0
 Icon=account
+NoDisplay=true
 X-Ubuntu-Single-Instance=true
 X-Ubuntu-Splash-Show-Header=false


### PR DESCRIPTION
Fixes https://github.com/ubports/ubuntu-touch/issues/1065 by setting the [NoDisplay property](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) in the desktop file.