### PR TITLE
Use Default Height Button

### DIFF
--- a/accounts/plugin/qml/NewAccount.qml
+++ b/accounts/plugin/qml/NewAccount.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import Ubuntu.Components 1.3
 import Ubuntu.OnlineAccounts 0.1
 
@@ -87,7 +87,6 @@ Item {
             Button {
                 id: btnCancel
                 text: i18n.dtr("sync-monitor", "Cancel")
-                height: parent.height
                 width: (parent.width / 2) - 0.5 * parent.spacing
                 onClicked: finished()
             }
@@ -95,7 +94,6 @@ Item {
                 id: btnContinue
                 text: i18n.dtr("sync-monitor", "Continue")
                 color: UbuntuColors.green
-                height: parent.height
                 width: (parent.width / 2) - 0.5 * parent.spacing
                 onClicked: login()
                 enabled: !__busy


### PR DESCRIPTION
- Bumped QtQuick version
- Use Default height for Button (to fit the system style)

Before, after:

![image](https://user-images.githubusercontent.com/6640041/60149500-2cfb3680-97d5-11e9-921b-ac4f6b0f829b.png)
