### PR TITLE
Change to using full AppID like the click hooks

### DIFF
--- a/authenticator/main.qml
+++ b/authenticator/main.qml
@@ -17,7 +17,7 @@ MainView {
         id: accountModel
 
         serviceId: ONLINE_ACCOUNT.serviceName
-        applicationId: "com.ubuntu.calendar"
+        applicationId: "com.ubuntu.calendar_calendar"
         onReadyChanged:  {
             console.debug("Model is Ready:" + ready)
             console.debug("Model count:" + count)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sync-monitor (0.4~0ubports2) xenial; urgency=medium
+
+  * Change to using full AppID like the click hooks
+
+ -- Dalton Durst <dalton@ubports.com>  Tue, 13 Aug 2019 14:25:14 -0500
+
 sync-monitor (0.4~0ubports1) xenial; urgency=medium
 
   * Version bump


### PR DESCRIPTION
I'm unsure exactly when this change occurred, but the files in `~/.local/share/accounts/applications/` are now called `com.company.app_app` instead of simply `com.company.app`. I'm also unsure if this is a bug, but it's pretty easy to update software for the new naming scheme.

Fixes https://github.com/ubports/ubuntu-touch/issues/1191