### PR TITLE
Spelling: Could not, authenticated, …

### DIFF
--- a/authenticator/main.qml
+++ b/authenticator/main.qml
@@ -85,7 +85,7 @@ MainView {
 
             Label {
                 anchors.centerIn: parent
-                text: i18n.tr("Failed to load account information.")
+                text: i18n.tr("Could not load account info.")
             }
         }
     }
@@ -117,13 +117,13 @@ MainView {
                 } else {
                     accountPage.loginInProcess = false
                     root.wasAuthenticated = true
-                    console.debug("Authentication successful.")
+                    console.debug("Authenticated.")
                     Qt.quit()
                 }
             }
 
 
-            title: accountPage.loginInProcess ? i18n.tr("Logging in...") : i18n.tr("Sign in to sync")
+            title: accountPage.loginInProcess ? i18n.tr("Logging in…") : i18n.tr("Sign in to sync")
 
             head.backAction: Action {
                 iconName: "back"

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -38,6 +38,7 @@ if(XGETTEXT_EXECUTABLE)
                 --keyword=dtr:2 --keyword=dtr:2,3
                 --package-name=${DOMAIN}
                 --copyright-holder='Canonical Ltd.'
+                --from-code=utf-8
                 -D ${CMAKE_SOURCE_DIR} ${I18N_QMLS}
                 -D ${CMAKE_SOURCE_DIR} ${I18N_SRCS}
                 -s -p ${CMAKE_CURRENT_SOURCE_DIR} ${I18N_SRCS}

--- a/po/sync-monitor.pot
+++ b/po/sync-monitor.pot
@@ -38,7 +38,7 @@ msgid "Expired connection certificate"
 msgstr ""
 
 #: src/sync-account.cpp:772
-msgid "Connection certificate is invalid"
+msgid "Invalid connection certificate"
 msgstr ""
 
 #: src/sync-account.cpp:768

--- a/po/sync-monitor.pot
+++ b/po/sync-monitor.pot
@@ -1,115 +1,150 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) YEAR Canonical Ltd.
+# This file is distributed under the same license as the sync-monitor package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: sync-monitor\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-10 18:43+0000\n"
+"POT-Creation-Date: 2020-02-20 12:20-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/sync-account.cpp:739
-msgid "Failed to configure account"
+#: authenticator/main.qml:153
+msgid "Account sign-in failed. Please select your account to sign back in."
 msgstr ""
 
-#: ../src/sync-account.cpp:748
-msgid "Forbidden / access denied"
+#: authenticator/main.qml:60 authenticator/main.qml:78
+msgid "Accounts"
 msgstr ""
 
-#: ../src/sync-account.cpp:750
-msgid "Object not found / unassigned field"
-msgstr ""
-
-#: ../src/sync-account.cpp:752
-msgid "Command not allowed"
-msgstr ""
-
-#: ../src/sync-account.cpp:755
-msgid "Proxy authentication required"
-msgstr ""
-
-#: ../src/sync-account.cpp:757
-msgid "Disk full"
-msgstr ""
-
-#: ../src/sync-account.cpp:759
-msgid "Failed to sync due to a remote problem"
-msgstr ""
-
-#: ../src/sync-account.cpp:761
-msgid "Failed to run \"two-way\" sync"
-msgstr ""
-
-#: ../src/sync-account.cpp:763
-msgid "Failed to sync some items"
-msgstr ""
-
-#: ../src/sync-account.cpp:765
-msgid "Process died unexpectedly"
-msgstr ""
-
-#: ../src/sync-account.cpp:768
-msgid "Server sent bad content"
-msgstr ""
-
-#: ../src/sync-account.cpp:770
-msgid "Sync canceled"
-msgstr ""
-
-#: ../src/sync-account.cpp:772
-msgid "Connection timeout"
-msgstr ""
-
-#: ../src/sync-account.cpp:774
-msgid "Connection certificate has expired"
-msgstr ""
-
-#: ../src/sync-account.cpp:776
-msgid "Connection certificate is invalid"
-msgstr ""
-
-#: ../src/sync-account.cpp:780
-msgid "Failed to connect to the server"
-msgstr ""
-
-#: ../src/sync-account.cpp:783
-msgid "Server not found"
-msgstr ""
-
-#: ../src/sync-account.cpp:785
-msgid "Unknown status"
-msgstr ""
-
-#: ../src/sync-daemon.cpp:623 ../src/sync-daemon.cpp:645
-#: ../src/sync-daemon.cpp:753 ../src/sync-daemon.cpp:772
-msgid "Synchronization"
-msgstr ""
-
-#: ../src/sync-daemon.cpp:624
+#: src/sync-daemon.cpp:628
 msgid "An account failed to sync. Would you like to sign in again?"
 msgstr ""
 
-#. TRANSLATORS: %1 is an account username, such as an email address
-#: ../src/sync-daemon.cpp:647
-msgid "Syncing %1 (Calendar)"
+#: src/sync-account.cpp:748
+msgid "Command not allowed"
 msgstr ""
 
-#: ../src/sync-daemon.cpp:754
+#: src/sync-account.cpp:770
+msgid "Connection certificate has expired"
+msgstr ""
+
+#: src/sync-account.cpp:772
+msgid "Connection certificate is invalid"
+msgstr ""
+
+#: src/sync-account.cpp:768
+msgid "Connection timeout"
+msgstr ""
+
+#: src/sync-account.cpp:776
+msgid "Could not connect to the server"
+msgstr ""
+
+#: authenticator/main.qml:88
+msgid "Could not load account info."
+msgstr ""
+
+#: src/sync-account.cpp:757
+msgid "Could not run \"two-way\" sync"
+msgstr ""
+
+#: src/sync-daemon.cpp:760
+#, qt-format
 msgid ""
-"Fail to sync calendar %1 from account %2.\n"
+"Could not sync calendar %1 from account %2.\n"
 "%3"
 msgstr ""
 
+#: src/sync-account.cpp:755
+msgid "Could not sync due to a remote problem"
+msgstr ""
+
+#: src/sync-account.cpp:759
+msgid "Could not sync some items"
+msgstr ""
+
+#: src/sync-account.cpp:753
+msgid "Disk full"
+msgstr ""
+
+#: src/sync-account.cpp:735
+msgid "Failed to configure account"
+msgstr ""
+
 #. TRANSLATORS: %1 is an account username, such as an email address
-#: ../src/sync-daemon.cpp:774
+#: src/sync-daemon.cpp:780
+#, qt-format
 msgid "Finished syncing %1 (Calendar)"
+msgstr ""
+
+#: src/sync-account.cpp:744
+msgid "Forbidden / access denied"
+msgstr ""
+
+#: authenticator/main.qml:126
+msgid "Logging in…"
+msgstr ""
+
+#: src/notify-message.cpp:88
+msgid "No"
+msgstr ""
+
+#: src/sync-account.cpp:746
+msgid "Object not found / unassigned field"
+msgstr ""
+
+#: src/sync-account.cpp:761
+msgid "Process died unexpectedly"
+msgstr ""
+
+#: src/sync-account.cpp:751
+msgid "Proxy authentication required"
+msgstr ""
+
+#: authenticator/main.qml:82 authenticator/main.qml:130
+msgid "Quit"
+msgstr ""
+
+#: src/sync-account.cpp:779
+msgid "Server not found"
+msgstr ""
+
+#: src/sync-account.cpp:764
+msgid "Server sent bad content"
+msgstr ""
+
+#: authenticator/main.qml:126
+msgid "Sign in to sync"
+msgstr ""
+
+#: src/sync-account.cpp:766
+msgid "Sync canceled"
+msgstr ""
+
+#: src/sync-daemon.cpp:627 src/sync-daemon.cpp:649 src/sync-daemon.cpp:759
+#: src/sync-daemon.cpp:778
+msgid "Synchronization"
+msgstr ""
+
+#. TRANSLATORS: %1 is an account username, such as an email address
+#: src/sync-daemon.cpp:651
+#, qt-format
+msgid "Syncing %1 (Calendar)"
+msgstr ""
+
+#: src/sync-account.cpp:781
+msgid "Unknown status"
+msgstr ""
+
+#: src/notify-message.cpp:83
+msgid "Yes"
 msgstr ""

--- a/po/sync-monitor.pot
+++ b/po/sync-monitor.pot
@@ -34,7 +34,7 @@ msgid "Command not allowed"
 msgstr ""
 
 #: src/sync-account.cpp:770
-msgid "Connection certificate has expired"
+msgid "Expired connection certificate"
 msgstr ""
 
 #: src/sync-account.cpp:772

--- a/po/sync-monitor.pot
+++ b/po/sync-monitor.pot
@@ -42,7 +42,7 @@ msgid "Connection certificate is invalid"
 msgstr ""
 
 #: src/sync-account.cpp:768
-msgid "Connection timeout"
+msgid "Connection timed out"
 msgstr ""
 
 #: src/sync-account.cpp:776

--- a/po/sync-monitor.pot
+++ b/po/sync-monitor.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sync-monitor\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-20 12:20-0600\n"
+"POT-Creation-Date: 2020-02-20 15:14-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,15 +34,15 @@ msgid "Command not allowed"
 msgstr ""
 
 #: src/sync-account.cpp:770
-msgid "Expired connection certificate"
+msgid "Connection certificate has expired"
 msgstr ""
 
 #: src/sync-account.cpp:772
-msgid "Invalid connection certificate"
+msgid "Connection certificate is invalid"
 msgstr ""
 
 #: src/sync-account.cpp:768
-msgid "Connection timed out"
+msgid "Connection timeout"
 msgstr ""
 
 #: src/sync-account.cpp:776

--- a/src/sync-account.cpp
+++ b/src/sync-account.cpp
@@ -136,7 +136,7 @@ bool SyncAccount::prepareSession(const QString &session)
         attachSession(sessionProxy);
         return true;
     } else {
-        qWarning() << "Fail to open session" << sessionName;
+        qWarning() << "Could not open session" << sessionName;
         return false;
     }
 }
@@ -398,7 +398,7 @@ void SyncAccount::removeOldConfig() const
         if (configDir.removeRecursively()) {
             qDebug() << "\tsource dir removed" << configPath;
         } else {
-            qWarning() << "\tFail to remove source dir" << configPath;
+            qWarning() << "\tCould not remove source dir" << configPath;
         }
     } else {
         qDebug() << "\tOld config dir not found" << configDir.absolutePath();
@@ -417,7 +417,7 @@ void SyncAccount::removeOldConfig() const
         if (configDir.removeRecursively()) {
             qDebug() << "\tpeer dir removed" << configPath;
         } else {
-            qWarning() << "\tFail to remove peer dir" << configPath;
+            qWarning() << "\tCould not remove peer dir" << configPath;
         }
     } else {
         qDebug() << "\tOld config dir not found" << configDir.absolutePath();
@@ -440,7 +440,7 @@ void SyncAccount::removeConfig()
             if (configDir.removeRecursively()) {
                 qDebug() << "Config dir removed" << configPath;
             } else {
-                qWarning() << "Fail to remove config dir" << configPath;
+                qWarning() << "Could not remove config dir" << configPath;
             }
         }
     }
@@ -752,11 +752,11 @@ QString SyncAccount::statusDescription(const QString &status)
     case 420:
         return _("Disk full");
     case 506:
-        return _("Failed to sync due to a remote problem");
+        return _("Could not sync due to a remote problem");
     case 22000:
-        return _("Failed to run \"two-way\" sync");
+        return _("Could not run \"two-way\" sync");
     case 22001:
-        return _("Failed to sync some items");
+        return _("Could not sync some items");
     case 22002:
         return _("Process died unexpectedly");
     case 20006:
@@ -773,7 +773,7 @@ QString SyncAccount::statusDescription(const QString &status)
     case 20026:
     case 20027:
     case 20028:
-        return _("Failed to connect to the server");
+        return _("Could not connect to the server");
     case 20046:
     case 20047:
         return _("Server not found");
@@ -792,7 +792,7 @@ void SyncAccount::fetchRemoteSources(const QString &serviceName)
     connect(auth, SIGNAL(fail()), SLOT(onAuthFailed()));
     if (!auth->authenticate()) {
         auth->deleteLater();
-        qWarning() << "fail to authenticate account!";
+        qWarning() << "Could not authenticate account!";
         Q_EMIT remoteSourcesAvailable(m_remoteSources, 304);
     }
 }
@@ -838,14 +838,14 @@ void SyncAccount::onReplyFinished(QNetworkReply *reply)
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
-        qWarning() << "Fail to fetch remote sources:" << reply->errorString();
+        qWarning() << "Could not fetch remote sources:" << reply->errorString();
         Q_EMIT remoteSourcesAvailable(m_remoteSources, reply->error() == QNetworkReply::AuthenticationRequiredError ? 403 : 20007);
         return;
     }
 
     int responseCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     if (responseCode != 200) {
-        qWarning() << "Fail to fetch remote sources response:" << responseCode;
+        qWarning() << "Could not fetch remote source response:" << responseCode;
         Q_EMIT remoteSourcesAvailable(m_remoteSources, 20007);
         return;
     }
@@ -916,7 +916,7 @@ void SyncAccount::fetchRemoteCalendarsFromCommand(const QString &username, const
     syncEvo->start("syncevolution", args);
     connect(syncEvo, SIGNAL(finished(int,QProcess::ExitStatus)),
             SLOT(fetchRemoteCalendarsProcessDone(int,QProcess::ExitStatus)));
-    qDebug() << "Fetching remote calendars (wait...)";
+    qDebug() << "Fetching remote calendars…)";
 }
 
 void SyncAccount::fetchRemoteCalendarsProcessDone(int exitCode, QProcess::ExitStatus exitStatus)

--- a/src/sync-daemon.cpp
+++ b/src/sync-daemon.cpp
@@ -483,7 +483,7 @@ void SyncDaemon::addAccount(const AccountId &accountId, bool startSync)
 {
     Account *acc = m_manager->account(accountId);
     if (!acc) {
-        qWarning() << "Fail to retrieve accounts:" << m_manager->lastError().message();
+        qWarning() << "Could not retrieve accounts:" << m_manager->lastError().message();
     } else if (m_provider->contains(acc->providerName())) {
         qDebug() << "Found account:" << acc->displayName();
         SyncAccount *syncAcc = new SyncAccount(acc,
@@ -747,7 +747,7 @@ void SyncDaemon::onAccountSyncFinished(const QString &serviceName,
             fail = true;
             saveLog = false;
             // white list error retry the sync
-            qDebug() << "Trying a second sync due error:" << errorMessage;
+            qDebug() << "Attempting to sync again:" << errorMessage;
             m_syncQueue->push(acc, QStringList(), false);
             break;
         } else if (!errorMessage.isEmpty()) {
@@ -757,7 +757,7 @@ void SyncDaemon::onAccountSyncFinished(const QString &serviceName,
             if (firstSync || !whiteListStatus.contains(status)) {
                 NotifyMessage *notify = new NotifyMessage(true, this);
                 notify->show(_("Synchronization"),
-                             QString(_("Fail to sync calendar %1 from account %2.\n%3"))
+                             QString(_("Could not sync calendar %1 from account %2.\n%3"))
                                  .arg(source)
                                  .arg(acc->displayName())
                                  .arg(errorMessage),


### PR DESCRIPTION
The [translation platform](https://translate.ubports.com/translate/ubports/sync-monitor/nb/?checksum=945b580887c2979f) somehow has
https://github.com/ubports/sync-monitor/blob/8dfcae07341f969deb6dc536e7f5fcd1dec05278/authenticator/main.qml#L126
in it
